### PR TITLE
Deal with insights-client returning more than just playbook

### DIFF
--- a/receptor_satellite/playbook_verifier_adapter.py
+++ b/receptor_satellite/playbook_verifier_adapter.py
@@ -19,7 +19,11 @@ def verify(playbook):
         )
         outs, errs = sub.communicate(bytes(playbook, "utf-8"))
         if sub.returncode == 0:
-            return outs.decode("utf-8")
+            decoded = outs.decode("utf-8")
+            start = decoded.find("---")
+            if start == -1:
+                start = 0
+            return decoded[start:]
         else:
             message = f"Playbook signature validation exit code: {sub.returncode}\n"
             message += outs.decode("utf-8") + "\n"

--- a/tests/test_playbook_verifier_adapter.py
+++ b/tests/test_playbook_verifier_adapter.py
@@ -10,7 +10,9 @@ class FakePopen:
 
     def communicate(self, input):
         if self.response is None:
-            return [input, b""]
+            response = "Playbook Verification has started\nAll templates successfully validated\n"
+            response += input.decode("utf-8")
+            return [bytes(response, "utf-8"), b""]
         else:
             return self.response
 
@@ -22,6 +24,14 @@ def __raise_oserror(*args, **kwargs):
 def test_success():
     old_popen = subprocess.Popen
     subprocess.Popen = lambda *args, **kwargs: FakePopen()
+    result = playbook_verifier_adapter.verify("---\n- hosts: all\n  tasks: []")
+    subprocess.Popen = old_popen
+    assert result == "---\n- hosts: all\n  tasks: []"
+
+
+def test_invalid_yaml():
+    old_popen = subprocess.Popen
+    subprocess.Popen = lambda *args, **kwargs: FakePopen(response=[b"Hello", b""])
     result = playbook_verifier_adapter.verify("Hello")
     subprocess.Popen = old_popen
     assert result == "Hello"


### PR DESCRIPTION
We expected the playbook validation to return only a clean playbook. We
didn't expect it would log some messages before outputting the playbook.

This change discards everything up until the leading triple dash. If it
is not found, whatever insights-client returns is used as the playbook
without any change.